### PR TITLE
Fix: An instance 0x685f030 of class LocationFetcher was deallocated while key value observers were still registered with it.

### DIFF
--- a/YandexMapKitSample/OnScreenButtonsViewController.m
+++ b/YandexMapKitSample/OnScreenButtonsViewController.m
@@ -130,11 +130,11 @@
 
 - (void)deallocOrUnload
 {
+    [self stopMonitoringLocationFetching];    
+
     self.locateMeButton = nil;
     self.locationFetcher = nil;
-    self.activityIndicator = nil;
-    
-    [self stopMonitoringLocationFetching];    
+    self.activityIndicator = nil;    
 }
 
 - (void)dealloc


### PR DESCRIPTION
An instance 0x685f030 of class LocationFetcher was deallocated while key value observers were still registered with it.

Observation info was leaked, and may even become mistakenly attached to some other object.
Set a breakpoint on NSKVODeallocateBreak to stop here in the debugger.

Here's the current observation info:
<NSKeyValueObservationInfo 0x6e44970> (
<NSKeyValueObservance 0x6e4a120: Observer: 0x6848520, Key path: fetchingLocation, Options: <New: NO, Old: NO, Prior: NO> Context: 0x0, Property: 0x6e44650>
)

The OnScreenButtonsViewController was observing its locationFetcher's fetchingLocation property and was zeroing out the reference to the locationFetcher in its dealloc method before removing the observer.

Changed the order of the calls to make the warning go away. All's now nice and dandy. :)
